### PR TITLE
fix proxyserver has no permission to create dir

### DIFF
--- a/deploy/foundation/hub/resources/proxyserver.yaml
+++ b/deploy/foundation/hub/resources/proxyserver.yaml
@@ -22,6 +22,8 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
           - "/acm-proxyserver"
+          - "--agent-cert-dir=/tmp/agent-cert"
+          - "--cert-dir=/tmp/cert"
           - "--secure-port=6443"
         livenessProbe:
           httpGet:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -51,4 +52,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	fakeManagedCluster, err := util.CreateManagedCluster(dynamicClient)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	fakeManagedClusterName = fakeManagedCluster.GetName()
+
+	gomega.Eventually(func() error {
+		return util.CheckFoundationPodsReady()
+	}, 60*time.Second, 2*time.Second).Should(gomega.Succeed())
+
 })


### PR DESCRIPTION
1. fix proxyserver has no permission (non-root) to create dir when `make deploy-foundation-hub`
```
$ kubectl logs -n open-cluster-management acm-proxyserver-54d4f8c7b5-ng5fq
error creating self-signed certificates: mkdir apiserver.local.config: permission denied
```
2. add e2e case to check if pods of foundation are ready.