### PR TITLE
fix that update clusterinfo labels constantly

### DIFF
--- a/pkg/controllers/autodetect/autodetect_controller.go
+++ b/pkg/controllers/autodetect/autodetect_controller.go
@@ -116,6 +116,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 	}
 
+	if len(labels) == 0 && len(clusterInfo.ObjectMeta.Labels) == 0 {
+		return ctrl.Result{}, nil
+	}
+
 	if !reflect.DeepEqual(labels, clusterInfo.ObjectMeta.Labels) {
 		clusterInfo.SetLabels(labels)
 		if err := r.client.Update(ctx, clusterInfo); err != nil {


### PR DESCRIPTION
fix that update clusterinfo labels constantly if the cluster and clusterinfo have no labels.

`clusterInfo.ObjectMeta.Labels == nil`, but `labels == map[string]string{} `
so `reflect.DeepEqual(labels, clusterInfo.ObjectMeta.Labels)` is always false.