### PR TITLE
ignoreNotFound error when get version in OCP3.x

### DIFF
--- a/pkg/klusterlet/clusterinfo/clusterinfo_controller.go
+++ b/pkg/klusterlet/clusterinfo/clusterinfo_controller.go
@@ -470,7 +470,7 @@ func (r *ClusterInfoReconciler) getOCPDistributionInfo() (clusterv1beta1.OCPDist
 	obj, err := r.ManagedClusterDynamicClient.Resource(ocpVersionGVR).Get(context.TODO(), "version", metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("failed to get OCP cluster version: %v", err)
-		return ocpDistributionInfo, "", err
+		return ocpDistributionInfo, "", client.IgnoreNotFound(err)
 	}
 
 	clusterID, _, err := unstructured.NestedString(obj.Object, "spec", "clusterID")


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

we cannot get ocp version in OCP 3.x, should ignore the NotFound error here for OCP 3.x.