### PR TITLE
Remove secret watch in inventory

### DIFF
--- a/pkg/controllers/inventory/inventory_controller.go
+++ b/pkg/controllers/inventory/inventory_controller.go
@@ -78,15 +78,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to secondary resource Secrets and requeue the owner BareMetalAsset
-	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &inventoryv1alpha1.BareMetalAsset{},
-	})
-	if err != nil {
-		return err
-	}
-
 	// Watch for changes to SyncSets and requeue BareMetalAssets with the name and matching cluster-deployment-namespace label
 	// (which is also the syncset namespace)
 	err = c.Watch(


### PR DESCRIPTION
relates to https://github.com/open-cluster-management/backlog/issues/8044

This is to reduce the mem consumption in ocm-controller. We do not need this watch since if secret is not found for a bma, we always requeue.