### PR TITLE
add clusterview rules to cluster admin and view roles

### DIFF
--- a/deploy/foundation/hub/resources/clusterviewv1-apiservice.yaml
+++ b/deploy/foundation/hub/resources/clusterviewv1-apiservice.yaml
@@ -9,5 +9,5 @@ spec:
     namespace: open-cluster-management
     name: foundation-proxyserver
   insecureSkipTLSVerify: true
-  groupPriorityMinimum: 10000
+  groupPriorityMinimum: 10
   versionPriority: 20

--- a/deploy/foundation/hub/resources/clusterviewv1alpha1-apiservice.yaml
+++ b/deploy/foundation/hub/resources/clusterviewv1alpha1-apiservice.yaml
@@ -9,5 +9,5 @@ spec:
     namespace: open-cluster-management
     name: foundation-proxyserver
   insecureSkipTLSVerify: true
-  groupPriorityMinimum: 10000
+  groupPriorityMinimum: 10
   versionPriority: 20

--- a/pkg/controllers/clusterrole/rbac.go
+++ b/pkg/controllers/clusterrole/rbac.go
@@ -11,6 +11,7 @@ import (
 )
 
 var managedclusterGroup = "cluster.open-cluster-management.io"
+var managedClusterViewGroup = "clusterview.open-cluster-management.io"
 
 // buildAdminRoleRules builds the clusteadminroles
 func buildAdminRoleRules(clusterName string) []rbacv1.PolicyRule {
@@ -19,6 +20,10 @@ func buildAdminRoleRules(clusterName string) []rbacv1.PolicyRule {
 			Groups(managedclusterGroup).
 			Resources("managedclusters").
 			Names(clusterName).
+			RuleOrDie(),
+		clusterrbac.NewRule("get", "list", "watch").
+			Groups(managedClusterViewGroup).
+			Resources("managedclusters").
 			RuleOrDie(),
 	}
 }
@@ -30,5 +35,9 @@ func buildViewRoleRules(clusterName string) []rbacv1.PolicyRule {
 			Groups(managedclusterGroup).
 			Resources("managedclusters").
 			Names(clusterName).RuleOrDie(),
+		clusterrbac.NewRule("get", "list", "watch").
+			Groups(managedClusterViewGroup).
+			Resources("managedclusters").
+			RuleOrDie(),
 	}
 }

--- a/pkg/proxyserver/cache/clusterview.go
+++ b/pkg/proxyserver/cache/clusterview.go
@@ -340,12 +340,20 @@ func getResourceNamesFromClusterRole(clusterRole *rbacv1.ClusterRole, group, res
 		if !rbac.APIGroupMatches(&rule, group) {
 			continue
 		}
+
+		if !rbac.VerbMatches(&rule, "get") && !rbac.VerbMatches(&rule, "list") {
+			continue
+		}
+
+		if len(rule.ResourceNames) == 0 {
+			all = true
+			return names, all
+		}
+
 		if !rbac.ResourceMatches(&rule, resource, "") {
 			continue
 		}
-		if len(rule.ResourceNames) == 0 {
-			all = true
-		}
+
 		names.Insert(rule.ResourceNames...)
 	}
 	return names, all

--- a/pkg/proxyserver/cache/clusterview_test.go
+++ b/pkg/proxyserver/cache/clusterview_test.go
@@ -81,6 +81,15 @@ func TestSyncManagedClusterCache(t *testing.T) {
 			expectedSets: sets.String{}.Insert("cluster1", "cluster2"),
 		},
 		{
+			name: "group4 no get role",
+			user: &user.DefaultInfo{
+				Name:   "group4",
+				UID:    "group4-uid",
+				Groups: []string{"group4"},
+			},
+			expectedSets: sets.String{},
+		},
+		{
 			name: "no user4",
 			user: &user.DefaultInfo{
 				Name:   "user4",

--- a/pkg/proxyserver/cache/managedcluster_test.go
+++ b/pkg/proxyserver/cache/managedcluster_test.go
@@ -78,6 +78,21 @@ var (
 					},
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "role4", ResourceVersion: "3"},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"list"},
+						APIGroups: []string{"clusterview.open-cluster-management.io"},
+						Resources: []string{"managedclusters"},
+					},
+					{
+						Verbs:     []string{"create"},
+						APIGroups: []string{"cluster.open-cluster-management.io"},
+						Resources: []string{"managedclusters"},
+					},
+				},
+			},
 		},
 	}
 	clusterRoleBindingList = rbacv1.ClusterRoleBindingList{
@@ -130,6 +145,22 @@ var (
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "ClusterRole",
 					Name:     "role3",
+				},
+			},
+			{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{Name: "rolebinding4", ResourceVersion: "2"},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     "Group",
+						APIGroup: "rbac.authorization.k8s.io",
+						Name:     "group4",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     "role4",
 				},
 			},
 		},
@@ -224,6 +255,15 @@ func TestClusterCacheList(t *testing.T) {
 				Groups: []string{"group3"},
 			},
 			expectedClusters: sets.String{}.Insert("cluster1", "cluster2"),
+		},
+		{
+			name: "group4 no get role",
+			user: &user.DefaultInfo{
+				Name:   "group4",
+				UID:    "group4-uid",
+				Groups: []string{"group4"},
+			},
+			expectedClusters: sets.String{},
 		},
 		{
 			name: "no user4",

--- a/pkg/proxyserver/cache/rbac/allow.go
+++ b/pkg/proxyserver/cache/rbac/allow.go
@@ -46,3 +46,13 @@ func ResourceMatches(rule *rbacv1.PolicyRule, combinedRequestedResource, request
 
 	return false
 }
+
+func VerbMatches(rule *rbacv1.PolicyRule, requestedVerb string) bool {
+	for _, verb := range rule.Verbs {
+		if verb == requestedVerb {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/role.go
+++ b/pkg/utils/role.go
@@ -36,7 +36,7 @@ func GetClustersetInRules(rules []rbacv1.PolicyRule) sets.String {
 		if !ContainsString(rule.APIGroups, clusterv1alpha1.GroupName) {
 			continue
 		}
-		if !ContainsString(rule.Resources, "managedclustersets/bind") && !ContainsString(rule.Resources, "*") {
+		if !ContainsString(rule.Resources, "managedclustersets/bind") && !ContainsString(rule.Resources, "managedclustersets/join") && !ContainsString(rule.Resources, "*") {
 			continue
 		}
 

--- a/test/e2e/clusterview_test.go
+++ b/test/e2e/clusterview_test.go
@@ -339,8 +339,14 @@ var _ = ginkgo.Describe("Testing ClusterView to watch managedClusters", func() {
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 	ginkgo.It("should watch the managedClusters.clusterview successfully", func() {
-		watchedClient, err := userDynamicClient.Resource(managedClusterViewGVR).Watch(context.Background(), metav1.ListOptions{})
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		var watchedClient watch.Interface
+		var err error
+
+		gomega.Eventually(func() error {
+			watchedClient, err = userDynamicClient.Resource(managedClusterViewGVR).Watch(context.Background(), metav1.ListOptions{})
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
 		defer watchedClient.Stop()
 		go func() {
 			expectedClusters := []string{cluster.GetName()}
@@ -509,8 +515,14 @@ var _ = ginkgo.Describe("Testing ClusterView to watch managedClusterSets", func(
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 	ginkgo.It("should watch the managedClusterSets.clusterview successfully", func() {
-		watchedClient, err := userDynamicClient.Resource(managedClusterSetViewGVR).Watch(context.Background(), metav1.ListOptions{})
-		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		var watchedClient watch.Interface
+		var err error
+
+		gomega.Eventually(func() error {
+			watchedClient, err = userDynamicClient.Resource(managedClusterSetViewGVR).Watch(context.Background(), metav1.ListOptions{})
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
 		defer watchedClient.Stop()
 		go func() {
 			expectedClusterSets := []string{clusterSet.GetName()}


### PR DESCRIPTION
1. add clusterview rules into cluster admin/view clusterrole.
2. if user has  managedclustersets/join create role of a clusterset, add the user to the clusterset rolebinding to add cluster admin roles to the user.
3. user can only  get/list clusterview resources if user has get/list cluster roles.
4. add ut and fix e2e issue.