### PR TITLE
Search secret doesn't have ca.crt - use configmap

### DIFF
--- a/docs/proxyserver/proxyserver.md
+++ b/docs/proxyserver/proxyserver.md
@@ -28,6 +28,7 @@ data:
   sub-resource: "/searchdata"
   use-id: "true"
   secret: "kube-system/search-secret"
+  caConfigMap: "kube-system/search-caCrt-configmap"
 ```
 
 **data:**
@@ -37,8 +38,8 @@ data:
 * `path`: The path for agents to send requests.
 * `sub-resource`: The resource of requests from agents.
 * `use-id`: If true, the path of requests includes cluster name as ID. If false, there is no ID in the path.
-* `secret`: The secret with CA information to access the backend service. Format is `namespace/<secret-name>`.
-
+* `secret`: The secret with signed serving certificate and key pair information to access the backend service. Format is `namespace/<secret-name>`.
+* `caConfigMap`: The configmap with CA certificate information to access the backend service. Format is `namespace/<configMap-name>`.
 ## clusterstatus/log
 
 Proxy Server provides sub resource under `clusterstatus/log` for clients to get logs of container on managed clusters.

--- a/pkg/proxyserver/controller/controller.go
+++ b/pkg/proxyserver/controller/controller.go
@@ -226,7 +226,7 @@ func (c *ProxyServiceInfoController) generateServiceInfo(cm *corev1.ConfigMap) (
 	}
 	caConfigmap, err := c.client.CoreV1().ConfigMaps(caConfigMapNamespace).Get(context.TODO(), caConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get configmap in configmap %s/%s, %v", cm.Namespace, cm.Name, err)
+		return nil, fmt.Errorf("failed to get caConfigMap in configmap %s/%s, %v", cm.Namespace, cm.Name, err)
 	}
 
 	return &getter.ProxyServiceInfo{

--- a/pkg/proxyserver/controller/controller.go
+++ b/pkg/proxyserver/controller/controller.go
@@ -228,7 +228,7 @@ func (c *ProxyServiceInfoController) generateServiceInfo(cm *corev1.ConfigMap) (
 			TLSClientConfig: rest.TLSClientConfig{
 				CertData: secret.Data["tls.crt"],
 				KeyData:  secret.Data["tls.key"],
-				CAData:   secret.Data["ca.crt"],
+				// CAData:   secret.Data["ca.crt"],
 			},
 		},
 	}, nil

--- a/pkg/proxyserver/controller/controller.go
+++ b/pkg/proxyserver/controller/controller.go
@@ -229,6 +229,10 @@ func (c *ProxyServiceInfoController) generateServiceInfo(cm *corev1.ConfigMap) (
 		return nil, fmt.Errorf("failed to get caConfigMap in configmap %s/%s, %v", cm.Namespace, cm.Name, err)
 	}
 
+	if _, ok := caConfigmap.Data["service-ca.crt"]; !ok {
+		return nil, fmt.Errorf("failed to get service-ca.crt key in caConfigmap %s/%s", caConfigMapNamespace, caConfigMapName)
+
+	}
 	return &getter.ProxyServiceInfo{
 		Name:             cm.Namespace + "/" + cm.Name,
 		SubResource:      strings.Trim(cm.Data["sub-resource"], "/"),


### PR DESCRIPTION
ca.crt is removed from the search secret with cert manager removal

Based on this [doc]( https://docs.openshift.com/container-platform/4.1/authentication/certificates/service-serving-certificate.html#add-service-certi[…]rving-certificate), writing the ca.crt to a configmap and using that for connecting.

Also, to resolve canaries https://github.com/open-cluster-management/backlog/issues/11742